### PR TITLE
CSD-10707 – Fixes for am-report-processor

### DIFF
--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -1,17 +1,24 @@
 #!/usr/bin/env node
 'use strict';
 
-var fs = require('fs'),
-  prompt = require('cli-prompt'),
-  dbNameFlag = process.argv.indexOf('--datasource'),
-  dbName = (dbNameFlag > -1) ? process.argv[dbNameFlag + 1] : 'db',
-  dateSinceFlag = process.argv.indexOf('--since'),
-  dateSinceFilter = (dateSinceFlag > -1) ? process.argv[dateSinceFlag + 1] : '',
-  migrationsFolderFlag = process.argv.indexOf('--directory'),
-  migrationsFolder = process.cwd() + ( migrationsFolderFlag > -1 ? process.argv[migrationsFolderFlag + 1].replace(/\/?$/, '/') : '/server/migrations/'),
-  dbMigrationsFolder = migrationsFolder+dbName,
-  app = require(process.cwd() + '/server/server.js'),
-  datasource = app.dataSources[dbName];
+var fs = require('fs');
+var prompt = require('cli-prompt');
+
+var dbNameFlag = process.argv.indexOf('--datasource');
+var dbName = (dbNameFlag > -1) ? process.argv[dbNameFlag + 1] : 'db';
+
+var dateSinceFlag = process.argv.indexOf('--since');
+var dateSinceFilter = (dateSinceFlag > -1) ? process.argv[dateSinceFlag + 1] : '';
+
+var migrationsFolderFlag = process.argv.indexOf('--directory');
+var migrationsFolder = process.cwd() + (migrationsFolderFlag > -1 ? process.argv[migrationsFolderFlag + 1].replace(/\/?$/, '/') : '/server/migrations/');
+var dbMigrationsFolder = migrationsFolder + dbName;
+
+var appScriptFlag = process.argv.indexOf('--app-script');
+var appScript = appScriptFlag > -1 ? process.argv[appScriptFlag + 1] : '/server/server.js'
+var app = require(process.cwd() + appScript);
+
+var datasource = app.dataSources[dbName];
 
 if (!datasource) {
   console.log('datasource \'' + dbName + '\' not found!');
@@ -121,7 +128,7 @@ function migrateScripts(upOrDown) {
           console.log(err);
           process.exit(1);
         }
-        
+
         var migrationCallStack = [],
           migrationCallIndex = 0;
 

--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -1,24 +1,24 @@
 #!/usr/bin/env node
 'use strict';
 
-var fs = require('fs');
-var prompt = require('cli-prompt');
+const fs = require('fs');
+const prompt = require('cli-prompt');
 
-var dbNameFlag = process.argv.indexOf('--datasource');
-var dbName = (dbNameFlag > -1) ? process.argv[dbNameFlag + 1] : 'db';
+const dbNameFlag = process.argv.indexOf('--datasource');
+const dbName = (dbNameFlag > -1) ? process.argv[dbNameFlag + 1] : 'db';
 
-var dateSinceFlag = process.argv.indexOf('--since');
-var dateSinceFilter = (dateSinceFlag > -1) ? process.argv[dateSinceFlag + 1] : '';
+const dateSinceFlag = process.argv.indexOf('--since');
+const dateSinceFilter = (dateSinceFlag > -1) ? process.argv[dateSinceFlag + 1] : '';
 
-var migrationsFolderFlag = process.argv.indexOf('--directory');
-var migrationsFolder = process.cwd() + (migrationsFolderFlag > -1 ? process.argv[migrationsFolderFlag + 1].replace(/\/?$/, '/') : '/server/migrations/');
-var dbMigrationsFolder = migrationsFolder + dbName;
+const migrationsFolderFlag = process.argv.indexOf('--directory');
+const migrationsFolder = process.cwd() + (migrationsFolderFlag > -1 ? process.argv[migrationsFolderFlag + 1].replace(/\/?$/, '/') : '/server/migrations/');
+const dbMigrationsFolder = migrationsFolder + dbName;
 
-var appScriptFlag = process.argv.indexOf('--app-script');
-var appScript = appScriptFlag > -1 ? process.argv[appScriptFlag + 1] : '/server/server.js'
-var app = require(process.cwd() + appScript);
+const appScriptFlag = process.argv.indexOf('--app-script');
+const appScript = appScriptFlag > -1 ? process.argv[appScriptFlag + 1] : '/server/server.js';
+const app = require(process.cwd() + appScript);
 
-var datasource = app.dataSources[dbName];
+const datasource = app.dataSources[dbName];
 
 if (!datasource) {
   console.log('datasource \'' + dbName + '\' not found!');
@@ -46,25 +46,28 @@ datasource.createModel('Migration', {
 // make migration folders if they don't exist
 try {
   fs.mkdirSync(migrationsFolder);
-} catch (e) {}
+} catch (e) {
+}
+
 try {
   fs.mkdirSync(dbMigrationsFolder);
-} catch (e) {}
+} catch (e) {
+}
 
-function mapScriptObjName(scriptObj){
+function mapScriptObjName(scriptObj) {
   return scriptObj.name;
 }
 
 function findScriptsToRun(upOrDown, cb) {
-  var filters = {
+  const filters = {
     where: {
-      name: { gte: dateSinceFilter+'' || '' }
+      name: {gte: dateSinceFilter + '' || ''}
     },
-    order: (upOrDown === 'up' ) ? 'name ASC' : 'name DESC'
+    order: (upOrDown === 'up') ? 'name ASC' : 'name DESC'
   };
 
   // get all local scripts and filter for only .js files
-  var localScriptNames = fs.readdirSync(dbMigrationsFolder).filter(function(fileName) {
+  const localScriptNames = fs.readdirSync(dbMigrationsFolder).filter(function (fileName) {
     return fileName.substring(fileName.length - 3, fileName.length) === '.js';
   });
 
@@ -85,7 +88,7 @@ function findScriptsToRun(upOrDown, cb) {
       }
 
       if (upOrDown === 'up') {
-        var runScriptsNames = scriptsRun.map(mapScriptObjName);
+        const runScriptsNames = scriptsRun.map(mapScriptObjName);
 
         // return scripts that exist on disk but not in the db
         cb(localScriptNames.filter(function (scriptName) {
@@ -123,14 +126,14 @@ function waitForAppToBeBooted(done) {
 function migrateScripts(upOrDown) {
   return function findAndRunScripts() {
     findScriptsToRun(upOrDown, function runScripts(scriptsToRun) {
-      waitForAppToBeBooted(function (err){
+      waitForAppToBeBooted(function (err) {
         if (err) {
           console.log(err);
           process.exit(1);
         }
 
-        var migrationCallStack = [],
-          migrationCallIndex = 0;
+        const migrationCallStack = [];
+        let migrationCallIndex = 0;
 
         scriptsToRun.forEach(function (localScriptName) {
           migrationCallStack.push(function () {
@@ -140,10 +143,10 @@ function migrateScripts(upOrDown) {
               if (err) {
                 console.log('Error saving migration', localScriptName, 'to database!');
                 console.log(err.stack);
-                process.exit(1);;
+                process.exit(1);
               }
 
-              console.log(localScriptName, 'finished sucessfully.');
+              console.log(localScriptName, 'finished successfully.');
               migrationCallIndex++;
               if (migrationCallIndex < migrationCallStack.length) {
                 migrationCallStack[migrationCallIndex]();
@@ -193,39 +196,39 @@ function migrateScripts(upOrDown) {
 }
 
 function stringifyAndPadLeading(num) {
-  var str = num + '';
+  const str = num + '';
   return (str.length === 1) ? '0' + str : str;
 }
 
-var cmds = {
+const commands = {
   up: migrateScripts('up'),
   down: migrateScripts('down'),
   create: function create(name) {
-    var cmdLineName = name || process.argv[process.argv.indexOf('create') + 1];
+    const cmdLineName = name || process.argv[process.argv.indexOf('create') + 1];
 
     if (!cmdLineName) {
       return prompt('Enter migration script name:', create);
     }
 
-    var d = new Date(),
-      year = d.getFullYear() + '',
-      month = stringifyAndPadLeading(d.getMonth()+1),
-      day = stringifyAndPadLeading(d.getDate()),
-      hours = stringifyAndPadLeading(d.getHours()),
-      minutes = stringifyAndPadLeading(d.getMinutes()),
-      seconds = stringifyAndPadLeading(d.getSeconds()),
-      dateString = year + month + day + hours +  minutes + seconds,
-      fileName = '/' + dateString + (cmdLineName && cmdLineName.indexOf('--') === -1 ? '-' + cmdLineName : '') + '.js';
+    const d = new Date();
+    const year = d.getFullYear() + '';
+    const month = stringifyAndPadLeading(d.getMonth() + 1);
+    const day = stringifyAndPadLeading(d.getDate());
+    const hours = stringifyAndPadLeading(d.getHours());
+    const minutes = stringifyAndPadLeading(d.getMinutes());
+    const seconds = stringifyAndPadLeading(d.getSeconds());
+    const dateString = year + month + day + hours + minutes + seconds;
+    const fileName = '/' + dateString + (cmdLineName && cmdLineName.indexOf('--') === -1 ? '-' + cmdLineName : '') + '.js';
 
     fs.writeFileSync(dbMigrationsFolder + fileName, fs.readFileSync(__dirname + '/migration-skeleton.js'));
     process.exit();
   }
 };
 
-var cmdNames = Object.keys(cmds);
+const cmdNames = Object.keys(commands);
 
-for ( var i = 0 ; i < cmdNames.length; i++ ) {
+for (let i = 0; i < cmdNames.length; i++) {
   if (process.argv.indexOf(cmdNames[i]) > -1) {
-    return cmds[cmdNames[i]]();
+    return commands[cmdNames[i]]();
   }
 }

--- a/loopback-db-migrate.js
+++ b/loopback-db-migrate.js
@@ -18,6 +18,9 @@ const appScriptFlag = process.argv.indexOf('--app-script');
 const appScript = appScriptFlag > -1 ? process.argv[appScriptFlag + 1] : '/server/server.js';
 const app = require(process.cwd() + appScript);
 
+const migrationCollectionFlag = process.argv.indexOf('--migration-collection');
+const migrationCollection = migrationCollectionFlag > -1 ? process.argv[migrationCollectionFlag + 1] : 'Migration';
+
 app.on('booted', () => {
   const datasource = app.dataSources[dbName];
 
@@ -26,7 +29,7 @@ app.on('booted', () => {
     process.exit(1);
   }
 
-  datasource.createModel('Migration', {
+  datasource.createModel(migrationCollection, {
     "name": {
       "id": true,
       "type": "String",
@@ -73,7 +76,7 @@ app.on('booted', () => {
     });
 
     // create table if not exists
-    datasource.autoupdate('Migration', function (err) {
+    datasource.autoupdate(migrationCollection, function (err) {
       if (err) {
         console.log('Error retrieving migrations:');
         console.log(err.stack);
@@ -81,7 +84,7 @@ app.on('booted', () => {
       }
 
       // get all scripts that have been run from DB
-      datasource.models.Migration.find(filters, function (err, scriptsRun) {
+      datasource.models[migrationCollection].find(filters, function (err, scriptsRun) {
         if (err) {
           console.log('Error retrieving migrations:');
           console.log(err.stack);
@@ -143,13 +146,13 @@ app.on('booted', () => {
                   console.log(err.stack);
                   process.exit(1);
                 } else if (upOrDown === 'up') {
-                  datasource.models.Migration.create({
+                  datasource.models[migrationCollection].create({
                     name: localScriptName,
                     db: dbName,
                     runDtTm: new Date()
                   }, runNextScript);
                 } else {
-                  datasource.models.Migration.destroyAll({
+                  datasource.models[migrationCollection].destroyAll({
                     name: localScriptName
                   }, runNextScript);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@checkit/loopback-db-migrate",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "author": {
     "name": "Scott Lively"
   },


### PR DESCRIPTION
* Allow the app script to not be `server/server.js`
* Loopback Boot 3 asynchronously sets up the datasources, so wait for the app to boot before running the migrations. Take this opportunity to remove the polling loop.